### PR TITLE
Fix umd import in node environment

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
   output: {
     library: 'propTypesFaker',
     libraryTarget: 'umd',
+    globalObject: 'typeof self !== \'undefined\' ? self : this',
     filename: 'faker.js',
     path: path.resolve(__dirname, 'dist')
   },


### PR DESCRIPTION
Import in node gives the error: `ReferenceError: window is not defined`.

Resolved using the fix specified here: https://github.com/webpack/webpack/issues/6522#issuecomment-371120689